### PR TITLE
Improve legend layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ python FS_rules_current.py
 
 `FS_rules_current.py` represents the latest code, while the previous `FS_rules_Hzband_textreport_final.py` is kept in the repository for historical reference.
 
-Adjust configuration constants at the top of the script to change behaviour. In particular, `MAX_REL_CASES` controls how many cases are kept for each relative rule.
+Adjust configuration constants at the top of the script to change behaviour. In particular, `MAX_REL_CASES` controls how many cases are kept for each relative rule. `ENV_Z_SHIFT` sets the envelope-rule difference threshold used when absolute rules are enabled. You may override it by defining the environment variable before running, e.g. `ENV_Z_SHIFT=0.1 python FS_rules_current.py`. (The parameter has no effect unless `ENABLE_ABSOLUTE` is `True`.)
 
 ## Outputs
 


### PR DESCRIPTION
## Summary
- keep legend under last subplot with extra space
- switch legend to two columns
- show ENV_Z_SHIFT value when applying envelope rule
- document how to override ENV_Z_SHIFT in README

## Testing
- `python -m py_compile FS_rules_current.py`


------
https://chatgpt.com/codex/tasks/task_e_68418107b348832986f3691d420fddca