### PR TITLE
Fix legend layout overflow

### DIFF
--- a/FS_rules_ref.py
+++ b/FS_rules_ref.py
@@ -528,7 +528,7 @@ def plot_results(
         nrows = (n + ncols - 1) // ncols
         line_height = 0.03
         legend_height = nrows * line_height
-        bottom_margin = legend_height + 0.05
+        bottom_margin = min(legend_height + 0.05, 0.9)
         fig.subplots_adjust(bottom=bottom_margin)
         y_anchor = bottom_margin / 2
         fig.legend(handles, labels, loc="lower center", ncol=ncols, frameon=False, fontsize="small", bbox_to_anchor=(0.5, y_anchor))


### PR DESCRIPTION
## Summary
- prevent legend margin from exceeding figure height in `FS_rules_ref.py`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684d2b99e6b88329a89d56d201af8fb4