### PR TITLE
Add Python cache gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary
- add `.gitignore` to exclude `__pycache__` directories and `.pyc` files

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d2b9f56b88329b4d26dc05855cd25