### PR TITLE
Improve legend placement and line styles

### DIFF
--- a/FS_rules_current.py
+++ b/FS_rules_current.py
@@ -18,6 +18,7 @@ Outputs
     – ``zero_sequence.png``
 """
 
+import os
 import sys
 from pathlib import Path
 
@@ -34,7 +35,7 @@ MAX_HARMONIC = 4                 # Highest harmonic to check (2..MAX_HARMONIC)
 HARMONIC_BAND_HZ = 5.0  # ±Hz band around each harmonic (e.g. ±5 Hz of n·FUND)
 Z_REF, X_REF = 100.0, 50.0       # Reference impedances [Ω]
 CLUSTER_BAND = 0.03              # ±3% clustering for envelope rule (C3)
-ENV_Z_SHIFT = 0.05               # ±10% impedance difference for envelope rule (C3)
+ENV_Z_SHIFT = float(os.getenv("ENV_Z_SHIFT", "0.05"))  # Fractional |Z| difference for C3
 MIN_REL_LIST = 5                 # Minimum number of relative worst cases
 MAX_REL_CASES = 5                # Max cases to keep per relative rule
 PEAK_PROMINENCE = None           # Prominence for find_peaks (None = no filtering)
@@ -52,7 +53,8 @@ FIG_ABS = Path("absolute_cases.png")
 #  - HARMONIC_BAND_HZ: window size around each harmonic. With FUND=60 and n=2,
 #      the band spans 120±5 Hz (115–125 Hz).
 #  - PEAK_PROMINENCE: threshold for scipy.find_peaks; if None, all local maxima count.
-#  - Z_REF, X_REF, CLUSTER_BAND, ENV_Z_SHIFT: absolute‐rule thresholds; adjust per your study.
+#  - Z_REF, X_REF, CLUSTER_BAND, ENV_Z_SHIFT: absolute‐rule thresholds. ENV_Z_SHIFT
+#    can also be set via the environment variable ``ENV_Z_SHIFT``.
 
 # ─────────────────────────────────────────────────────────────────────────
 # Build LABELS dictionary including new exact/peak tags
@@ -309,7 +311,7 @@ def main():
             print(f"    {rule} → {winner}")
     
         # 5. Envelope rule C3
-        print("▶ 5. Applying envelope rule C3 …")
+        print(f"▶ 5. Applying envelope rule C3 (ENV_Z_SHIFT={ENV_Z_SHIFT}) …")
         for c in cases:
             if c in sel_abs:
                 continue
@@ -509,15 +511,32 @@ def main():
     def reserve_and_legend(fig, axs, handles, raw_labels, tag_map, expl_map):
         labels = [f"{c}: {tag_map[c]} – {expl_map[c]}" for c in raw_labels]
         n = len(labels)
+        ncols = 2
+        nrows = (n + ncols - 1) // ncols
         line_height = 0.03
-        legend_height = n * line_height
-        bottom_margin = min(0.05 + legend_height + 0.02, 0.5)
+        legend_height = nrows * line_height
+        bottom_margin = 0.05 + legend_height + 0.02
+        width, height = fig.get_size_inches()
+        if bottom_margin > 0.5:
+            scale = bottom_margin / 0.5
+            fig.set_size_inches(width, height * scale, forward=True)
+            bottom_margin = 0.5
         fig.subplots_adjust(top=0.95, bottom=bottom_margin, hspace=0.3)
         y_anchor = bottom_margin / 2
-        fig.legend(handles, labels, loc="lower center", ncol=1,
+        fig.legend(handles, labels, loc="lower center", ncol=ncols,
                    frameon=False, fontsize="small", bbox_to_anchor=(0.5, y_anchor))
     
-    def plot_sequence(axs, metrics, cases, label_func):
+    def style_for_case(case, tag_map):
+        tag = tag_map.get(case, "")
+        label = LABELS.get(tag, "")
+        style = {}
+        if "Highest" in label:
+            style["linewidth"] = 2.5
+        if "peak" in tag:
+            style["linestyle"] = ":"
+        return style
+
+    def plot_sequence(axs, metrics, cases, label_func, tag_map):
         """Plot each metric for the given cases."""
         for ax, (_, df, ylabel) in zip(axs, metrics):
             for n in harmonics:
@@ -525,7 +544,8 @@ def main():
                 ax.axvline(n - bin_halfwidth, color="gray", linestyle=":", linewidth=0.8, alpha=0.7)
                 ax.axvline(n + bin_halfwidth, color="gray", linestyle=":", linewidth=0.8, alpha=0.7)
             for c in cases:
-                ax.plot(harmonic, df[c], label=label_func(c))
+                style = style_for_case(c, tag_map)
+                ax.plot(harmonic, df[c], label=label_func(c), **style)
             ax.set_ylabel(ylabel)
             ax.set_xticks(harmonics)
             ax.set_xticklabels([f"{n}H" for n in harmonics])
@@ -542,7 +562,7 @@ def main():
     ]
     fig1, axs1 = plt.subplots(4, 1, figsize=(10, 14), sharex=True)
 
-    h1, labs1 = plot_sequence(axs1, metrics_pos, pos_cases, lambda c: c)
+    h1, labs1 = plot_sequence(axs1, metrics_pos, pos_cases, lambda c: c, peer_first_tag)
 
     reserve_and_legend(fig1, axs1, h1, labs1, peer_first_tag, case_expl)
 
@@ -558,7 +578,7 @@ def main():
         ("Z0", Z0, "Z0 (Ω)"),
     ]
     fig2, axs2 = plt.subplots(4, 1, figsize=(8, 15), sharex=True)
-    h2, labs2 = plot_sequence(axs2, metrics_zero, zero_cases, lambda c: c)
+    h2, labs2 = plot_sequence(axs2, metrics_zero, zero_cases, lambda c: c, peer_first_tag)
     reserve_and_legend(fig2, axs2, h2, labs2, peer_first_tag, case_expl)
     fig2.savefig(FIG_ZERO, dpi=300)
     print(f"   ↳ saved {FIG_ZERO.name}")
@@ -572,16 +592,17 @@ def main():
         pos_abs = [c for c in abs_cases if not sel_abs[c].endswith("_0")]
         zero_abs = [c for c in abs_cases if sel_abs[c].endswith("_0")]
 
+        fig3, axs3 = plt.subplots(4, 2, figsize=(14, 15), sharex="col")
         handles, labels = [], []
         if pos_abs:
-            h3p, lab3p = plot_sequence(axs3[:, 0], metrics_pos, pos_abs, lambda c: c)
+            h3p, lab3p = plot_sequence(axs3[:, 0], metrics_pos, pos_abs, lambda c: c, abs_first_tag)
             handles.extend(h3p)
             labels.extend(lab3p)
         else:
             for ax in axs3[:, 0]:
                 ax.axis("off")
         if zero_abs:
-            h3z, lab3z = plot_sequence(axs3[:, 1], metrics_zero, zero_abs, lambda c: c)
+            h3z, lab3z = plot_sequence(axs3[:, 1], metrics_zero, zero_abs, lambda c: c, abs_first_tag)
             handles.extend(h3z)
             labels.extend(lab3z)
         else:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ python FS_rules_current.py
 
 `FS_rules_current.py` represents the latest code, while the previous `FS_rules_Hzband_textreport_final.py` is kept in the repository for historical reference.
 
-Adjust configuration constants at the top of the script to change behaviour. In particular, `MAX_REL_CASES` controls how many cases are kept for each relative rule.
+Adjust configuration constants at the top of the script to change behaviour. In particular, `MAX_REL_CASES` controls how many cases are kept for each relative rule. `ENV_Z_SHIFT` sets the envelope-rule difference threshold used when absolute rules are enabled. You may override it by defining the environment variable before running, e.g. `ENV_Z_SHIFT=0.1 python FS_rules_current.py`. (The parameter has no effect unless `ENABLE_ABSOLUTE` is `True`.)
 
 ## Outputs
 


### PR DESCRIPTION
## Summary
- keep legend under plots by scaling figure height when needed
- add line styling to highlight highest and peak cases

## Testing
- `python -m py_compile FS_rules_current.py`

------
https://chatgpt.com/codex/tasks/task_e_68418107b348832986f3691d420fddca