### PR TITLE
Fix workbook name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains the Python scripts for analyzing impedance sweeps store
 
 ## Input Workbook
 
-Provide `fs_seet.xlsx` with sheets `R1`, `X1`, `R0`, and `X0`. Each sheet should use frequency as the index and cases as columns.
+Provide `FS_sweep.xlsx` with sheets `R1`, `X1`, `R0`, and `X0`. Each sheet should use frequency as the index and cases as columns.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- correct the input workbook name in the README

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_684de6f51c388329a425d1a912a86283