### PR TITLE
Refactor metrics helpers

### DIFF
--- a/FS_rules_current.py
+++ b/FS_rules_current.py
@@ -237,16 +237,11 @@ def apply_absolute_rules(meta, cases):
     return sel_abs
 
 
-def select_relative_cases(meta, cases, sel_abs):
-    """Build relative peer-metric mapping and return rule cases and order."""
-    print("▶ 6. Building relative peer-metric list …")
-    peer_pool = [c for c in cases if c not in sel_abs]
-    peer_rule_cases = {}
-    peer_first_tag = {}
-
-    rel_order = []
+def build_relative_order():
+    """Return the sequence of relative-rule tags."""
+    order = []
     for n in range(2, MAX_HARMONIC + 1):
-        rel_order.extend(
+        order.extend(
             [
                 f"H-Z_exact({n}H)",
                 f"H-X_exact({n}H)",
@@ -257,7 +252,7 @@ def select_relative_cases(meta, cases, sel_abs):
             ]
         )
     for n in range(2, MAX_HARMONIC + 1):
-        rel_order.extend(
+        order.extend(
             [
                 f"H-Z0_exact({n}H)",
                 f"H-X0_exact({n}H)",
@@ -267,7 +262,7 @@ def select_relative_cases(meta, cases, sel_abs):
                 f"H-Q0_peak({n}H)",
             ]
         )
-    rel_order.extend([
+    order.extend([
         "Q-R",
         "R-Min",
         "E-Zero",
@@ -278,7 +273,13 @@ def select_relative_cases(meta, cases, sel_abs):
         "ΣZ0",
         "TopUp",
     ])
+    return order
 
+
+def collect_top_cases(meta, peer_pool):
+    """Return mapping of rule -> cases and first-tag map."""
+    peer_rule_cases = {}
+    peer_first_tag = {}
     for n in range(2, MAX_HARMONIC + 1):
         Z_exact = meta[f"Z1_exact_{n}"].loc[peer_pool]
         X_exact = meta[f"X1_exact_{n}"].abs().loc[peer_pool]
@@ -369,13 +370,11 @@ def select_relative_cases(meta, cases, sel_abs):
             for c in cases_sorted:
                 peer_rule_cases.setdefault(tag, []).append(c)
                 peer_first_tag.setdefault(c, tag)
+    return peer_rule_cases, peer_first_tag
 
-    total_selected = sum(len(v) for v in peer_rule_cases.values())
-    print(f"   Initial peer count = {total_selected}")
-    for tag in rel_order:
-        for c in peer_rule_cases.get(tag, []):
-            print(f"    {tag} → {c}")
 
+def apply_topup(meta, peer_rule_cases, peer_first_tag, rel_order):
+    """Add additional cases so the list meets MIN_REL_LIST."""
     ladder = (
         meta["Z1_pk"] / Z_REF
         + meta[[f"Z1_peak_{n}" for n in range(2, MAX_HARMONIC + 1)]].max(axis=1) / Z_REF
@@ -391,7 +390,21 @@ def select_relative_cases(meta, cases, sel_abs):
         peer_first_tag.setdefault(nxt, "TopUp")
         print(f"    TopUp → {nxt} (score={ladder[nxt]:.2f})")
     print(f"   Final peer count = {len(peer_first_tag)}")
+    return peer_rule_cases, peer_first_tag
 
+
+def select_relative_cases(meta, cases, sel_abs):
+    """Build relative peer-metric mapping and return rule cases and order."""
+    print("▶ 6. Building relative peer-metric list …")
+    peer_pool = [c for c in cases if c not in sel_abs]
+    rel_order = build_relative_order()
+    peer_rule_cases, peer_first_tag = collect_top_cases(meta, peer_pool)
+    total_selected = sum(len(v) for v in peer_rule_cases.values())
+    print(f"   Initial peer count = {total_selected}")
+    for tag in rel_order:
+        for c in peer_rule_cases.get(tag, []):
+            print(f"    {tag} → {c}")
+    peer_rule_cases, peer_first_tag = apply_topup(meta, peer_rule_cases, peer_first_tag, rel_order)
     return peer_rule_cases, peer_first_tag, rel_order
 
 

--- a/FS_rules_single.py
+++ b/FS_rules_single.py
@@ -61,41 +61,38 @@ def load_data(book: Path):
     return freqs, cases, R1, X1, R0, X0
 
 
-def compute_metrics(
-    freqs,
-    cases,
-    R1,
-    X1,
-    R0,
-    X0,
-    FUND: float,
-    MAX_HARMONIC: int,
-    HARMONIC_BAND_HZ: float,
-    INCLUDE_NEGATIVE_PEAKS: bool,
-    PEAK_PROMINENCE,
-):
-    """Compute base metrics and return them along with a meta dataframe."""
-    print("\u25B6 2. Computing base metrics (Z1, Z0, Q1, Q0, etc.) …")
-    Z1 = np.hypot(R1, X1)
-    Q1 = (X1.abs() / R1.replace(0, np.nan)).fillna(np.inf)
-    Z0 = np.hypot(R0, X0)
-    Q0 = (X0.abs() / R0.replace(0, np.nan)).fillna(np.inf)
-
+def compute_global_peaks(Z1, Q1, Z0, Q0):
+    """Return dataframe with global peak metrics for each case."""
+    cases = Z1.columns
     meta = pd.DataFrame(index=cases)
-
-    # 2.1 Global peaks (positive-sequence)
     meta["Z1_pk"] = Z1.max()
     meta["f_pk"] = Z1.idxmax()
     meta["Q1_pk"] = [Q1.at[meta.at[c, "f_pk"], c] for c in cases]
-
-    # 2.2 Global peaks (zero-sequence)
     meta["Z0_pk"] = Z0.max()
     meta["Q0_pk"] = [Q0.at[meta.at[c, "f_pk"], c] for c in cases]
+    return meta
 
-    # 2.3 Harmonic-exact and harmonic-bin-peak metrics
+
+def compute_harmonic_metrics(
+    freqs,
+    cases,
+    Z1,
+    X1,
+    R1,
+    Z0,
+    X0,
+    R0,
+    FUND,
+    MAX_HARMONIC,
+    HARMONIC_BAND_HZ,
+    INCLUDE_NEGATIVE_PEAKS,
+    PEAK_PROMINENCE,
+):
+    """Return dataframe with harmonic exact/peak metrics for each case."""
+    meta = pd.DataFrame(index=cases)
     for seq_label, Zdf, Xdf, Rdf in [
-        ("1", Z1, X1, R1),  # positive-sequence
-        ("0", Z0, X0, R0),  # zero-sequence
+        ("1", Z1, X1, R1),
+        ("0", Z0, X0, R0),
     ]:
         for n in range(2, MAX_HARMONIC + 1):
             f_target = n * FUND
@@ -156,13 +153,58 @@ def compute_metrics(
             meta[f"Z{seq_label}_peak_{n}"] = Z_peak
             meta[f"X{seq_label}_peak_{n}"] = X_at_peak
             meta[f"Q{seq_label}_peak_{n}"] = Q_peak.fillna(np.inf)
+    return meta
 
-    # 2.4 Min values and energy (area under |Z| curve)
+
+def compute_energy_metrics(freqs, cases, Z1, X1, R1, Z0, X0, R0):
+    """Return dataframe with energy, minima, etc."""
+    meta = pd.DataFrame(index=cases)
     meta["X1_min"], meta["R1_min"] = X1.min(), R1.min()
     meta["X0_min"], meta["R0_min"] = X0.min(), R0.min()
     trapz = getattr(np, "trapezoid", np.trapz)
     meta["ΣZ1"] = pd.Series(trapz(Z1.to_numpy(), x=freqs, axis=0), index=cases)
     meta["ΣZ0"] = pd.Series(trapz(Z0.to_numpy(), x=freqs, axis=0), index=cases)
+    return meta
+
+
+def compute_metrics(
+    freqs,
+    cases,
+    R1,
+    X1,
+    R0,
+    X0,
+    FUND: float,
+    MAX_HARMONIC: int,
+    HARMONIC_BAND_HZ: float,
+    INCLUDE_NEGATIVE_PEAKS: bool,
+    PEAK_PROMINENCE,
+):
+    """Compute base metrics and return them along with a meta dataframe."""
+    print("\u25B6 2. Computing base metrics (Z1, Z0, Q1, Q0, etc.) …")
+    Z1 = np.hypot(R1, X1)
+    Q1 = (X1.abs() / R1.replace(0, np.nan)).fillna(np.inf)
+    Z0 = np.hypot(R0, X0)
+    Q0 = (X0.abs() / R0.replace(0, np.nan)).fillna(np.inf)
+
+    meta = compute_global_peaks(Z1, Q1, Z0, Q0)
+    meta_h = compute_harmonic_metrics(
+        freqs,
+        cases,
+        Z1,
+        X1,
+        R1,
+        Z0,
+        X0,
+        R0,
+        FUND,
+        MAX_HARMONIC,
+        HARMONIC_BAND_HZ,
+        INCLUDE_NEGATIVE_PEAKS,
+        PEAK_PROMINENCE,
+    )
+    meta_e = compute_energy_metrics(freqs, cases, Z1, X1, R1, Z0, X0, R0)
+    meta = pd.concat([meta, meta_h, meta_e], axis=1)
 
     return meta, Z1, Z0, Q1, Q0
 


### PR DESCRIPTION
## Summary
- modularize base metric computation in core library
- break up relative-case selection into helper steps

## Testing
- `python -m py_compile FS_rules_current.py FS_rules_latest.py FS_rules_ref.py FS_rules_single.py fs_rules_core.py`


------
https://chatgpt.com/codex/tasks/task_e_684de40e11dc8329bb87f96189d5dab8