### PR TITLE
Fix legend height

### DIFF
--- a/FS_rules_single_bottom.py
+++ b/FS_rules_single_bottom.py
@@ -167,20 +167,43 @@ def compute_metrics(
     return meta, Z1, Z0, Q1, Q0
 
 
-def reserve_and_legend(fig, axs, handles, raw_labels, tag_map, expl_map, *, max_height=0.5):
-    """Adjust margins and place the legend below the plots."""
+def reserve_and_legend(fig, axs, handles, raw_labels, tag_map, expl_map):
+    """Add a bottom legend and expand the figure so it never overlaps plots."""
     labels = [f"{c}: {tag_map[c]} – {expl_map[c]}" for c in raw_labels]
-    fig.subplots_adjust(bottom=0.2, hspace=0.3)
-    fig.legend(
+
+    # Temporary legend to measure size based on number of entries
+    legend = fig.legend(
         handles,
         labels,
         loc="lower center",
-        bbox_to_anchor=(0.5, -0.05),
         ncol=2,
         frameon=False,
         fontsize="small",
+        bbox_to_anchor=(0.5, 0.0),
+        bbox_transform=fig.transFigure,
     )
-    fig.tight_layout()
+
+    # Force a draw so legend dimensions are known
+    fig.canvas.draw()
+    legend_height = legend.get_window_extent().height / fig.dpi
+
+    # Pad scales with one legend row height; this adapts to case count
+    n_rows = max(1, int(np.ceil(len(labels) / 2)))
+    row_height = legend_height / n_rows
+    pad_in = row_height * 0.7
+
+    new_height = fig.get_figheight() + legend_height + pad_in
+    fig.set_figheight(new_height)
+
+    bottom = (legend_height + pad_in) / new_height
+
+    # Reserve space for the legend and tighten layout within that box
+    fig.tight_layout(rect=[0, bottom, 1, 1], h_pad=0.3)
+    fig.subplots_adjust(bottom=bottom)
+
+    # Place legend centred in the reserved bottom margin
+    legend.set_bbox_to_anchor((0.5, bottom / 2), transform=fig.transFigure)
+
 
 
 def plot_sequence(axs, metrics, cases, label_func, harmonic, harmonics, bin_halfwidth, line_kwargs=None):


### PR DESCRIPTION
## Summary
- adjust reserve_and_legend so figure height expands to fit the legend
- ensure legend sits centered in reserved bottom space

## Testing
- `python -m py_compile FS_rules_single_bottom.py`
- `timeout 5s python FS_rules_single_bottom.py --help`


------
https://chatgpt.com/codex/tasks/task_e_684e934724548329a1d3b6316aab6776